### PR TITLE
fix chatty cloudtrail, cushion before panic from aws api calls

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -330,13 +330,20 @@ func GetDNSListByZoneIdFromAWS(zoneId string) (list []ResourceRecordSetType) {
     }
 
     // Loop requests in case there're more than PageSize records or we're being throttled
+    errcount := 0
     for {
         // Get batch of records
         resp, err := svc.ListResourceRecordSets(params)
         if err != nil {
-            if BeingThrottled(err) {   // Sleep for a moment if AWS is throttling us
+            // Sleep for a moment if AWS is throttling us
+            if BeingThrottled(err) {
                 fmt.Printf("  AWS throttling. Sleeping %d seconds...\n", APISecondsDelay)
                 time.Sleep(time.Duration(APISecondsDelay) * time.Second)
+                continue
+            }
+            // Allow for 3 other unknown API call errors before panicking
+            if errcount < 3 {
+                errcount++
                 continue
             }
             panic(err.Error())   // Abort on any other error

--- a/elb.go
+++ b/elb.go
@@ -310,13 +310,20 @@ func GetELBListFromAWS() (list []LoadBalancerDescriptionType) {
         PageSize: aws.Int64(400),  // 400 is AWS max request limit
     }
     // Loop requests in case there're more than PageSize records or we're being throttled
+    errcount := 0
     for {
         // Get batch of records
         resp, err := svc.DescribeLoadBalancers(params)
         if err != nil {
-            if BeingThrottled(err) {   // Sleep for a moment if AWS is throttling us
+            // Sleep for a moment if AWS is throttling us
+            if BeingThrottled(err) {
                 fmt.Printf("  AWS throttling. Sleeping %d seconds...\n", APISecondsDelay)
                 time.Sleep(time.Duration(APISecondsDelay) * time.Second)
+                continue
+            }
+            // Allow for 3 other unknown API call errors before panicking
+            if errcount < 3 {
+                errcount++
                 continue
             }
             panic(err.Error())   // Abort on any other error

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 // Global constants
 const (
     ProgName         = "awsinfo"
-    ProgVer          = "2.0.10"
+    ProgVer          = "2.0.11"
     DNSDataFile      = "dns.json"
     ZoneDataFile     = "zone.json"
     ELBDatafile      = "elb.json"

--- a/stack.go
+++ b/stack.go
@@ -156,13 +156,20 @@ func GetStackListFromAWS() (list []StackType) {
     params := &cloudformation.DescribeStacksInput{}
 
     // Loop requests in case there're more than PageSize records or we're being throttled
+    errcount := 0
     for {
         // Get batch of records
         resp, err := svc.DescribeStacks(params)
         if err != nil {
-            if BeingThrottled(err) {   // Sleep for a moment if AWS is throttling us
+            // Sleep for a moment if AWS is throttling us
+            if BeingThrottled(err) {
                 fmt.Printf("  AWS throttling. Sleeping %d seconds...\n", APISecondsDelay)
                 time.Sleep(time.Duration(APISecondsDelay) * time.Second)
+                continue
+            }
+            // Allow for 3 other unknown API call errors before panicking
+            if errcount < 3 {
+                errcount++
                 continue
             }
             panic(err.Error())   // Abort on any other error

--- a/zone.go
+++ b/zone.go
@@ -209,13 +209,20 @@ func GetZoneListFromAWS() (list []HostedZoneType) {
     }
 
     // Loop requests in case there're more than PageSize records or we're being throttled
+    errcount := 0
     for {
         // Get batch of records
         resp, err := svc.ListHostedZones(params)
         if err != nil {
-            if BeingThrottled(err) {   // Sleep for a moment if AWS is throttling us
+            // Sleep for a moment if AWS is throttling us
+            if BeingThrottled(err) {
                 fmt.Printf("  AWS throttling. Sleeping %d seconds...\n", APISecondsDelay)
                 time.Sleep(time.Duration(APISecondsDelay) * time.Second)
+                continue
+            }
+            // Allow for 3 other unknown API call errors before panicking
+            if errcount < 3 {
+                errcount++
                 continue
             }
             panic(err.Error())   // Abort on any other error


### PR DESCRIPTION
- Disregarding Cloudtrail events that 'List' or 'Describe'
- Allowing 3 failures on AWS API calls as a cushion. This is aside from the normal AWS throtling